### PR TITLE
Umami Analytics Konfiguration (hosted by tjsh)

### DIFF
--- a/config/_default/params.toml
+++ b/config/_default/params.toml
@@ -34,8 +34,8 @@ homepageImage = "IMG_0707.JPG"
 
 [article]
 showDate = true
-showViews = true
-showLikes = true
+showViews = false
+showLikes = false
 showDateOnlyInArticle = false
 showDateUpdated = false
 showAuthor = false
@@ -65,8 +65,8 @@ layoutBackgroundBlur = true
 layoutBackgroundHeaderSpace = true
 showBreadcrumbs = false
 showSummary = false
-showViews = true
-showLikes = true
+showViews = false
+showLikes = false
 showTableOfContents = false
 showCards = false
 orderByWeight = false
@@ -105,7 +105,7 @@ cardViewScreenWidth = false
 websiteid = "32341a18-15ca-4c02-8b6c-75eed0104a37"
 domain = "umami.tjsh.de"
 dataDomains = "feuerwehr-liekwegen.de,www.feuerwehr-liekwegen.de"
-enableTrackEvent = true
+enableTrackEvent = false
 
 [selineAnalytics]
 


### PR DESCRIPTION
Umami Analytics auf Toms Server (gleicher wie die Website), ohne access logs, laut Umami DSGVO Konform

https://umami.is/docs

https://umami.tjsh.de/